### PR TITLE
Switch TF version constraint to only lower bound

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "> 1.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Currently, this module uses a pessimistic constraint operator, which means that more recent version of terraform (e.g., `> 1.1.0`) throw a warning. This update aims to bring the module more in line with [reusable module best practices](https://www.terraform.io/language/expressions/version-constraints#terraform-core-and-provider-versions) by switching this for a minimum bound constraint instead.