### PR TITLE
ECS Environment Variables as Module Input

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -38,24 +38,10 @@ locals {
       essential = true
       cpu       = local.cpu
       memory    = local.memory
-      environment = [
-        {
-          name  = "TFC_AGENT_DISABLE_UPDATE"
-          value = "true"
-        },
-        {
-          name  = "TFC_AGENT_SINGLE"
-          value = "true"
-        },
-        {
-          name  = "TFC_AGENT_NAME"
-          value = "${var.name}-ecs"
-        },
-        {
-          name  = "TFC_AGENT_LOG_LEVEL"
-          value = "info"
-        },
-      ]
+      environment = merge([{
+        name  = "TFC_AGENT_NAME"
+        value = "${var.name}-ecs"
+      }], var.tfc_agent_env_vars)
       secrets = [
         {
           name      = "TFC_AGENT_TOKEN"

--- a/ecs.tf
+++ b/ecs.tf
@@ -38,7 +38,7 @@ locals {
       essential = true
       cpu       = local.cpu
       memory    = local.memory
-      environment = merge([{
+      environment = concat([{
         name  = "TFC_AGENT_NAME"
         value = "${var.name}-ecs"
       }], var.tfc_agent_env_vars)

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "security_groups" {
   description = "Security groups associated with ECS cluster."
   value       = local.security_groups
 }
+
+output "vpc_id" {
+  description = "VPC ID associated with ECS cluster. If create_vpc is false, output is an empty string."
+  value       = var.create_vpc ? module.vpc[0].vpc_id : ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,7 @@ variable "tfc_agent_env_vars" {
   default = [
     {
       name  = "TFC_AGENT_DISABLE_UPDATE"
-      value = "value"
+      value = "true"
     },
     {
       name  = "TFC_AGENT_SINGLE"

--- a/variables.tf
+++ b/variables.tf
@@ -60,8 +60,27 @@ variable "num_agents" {
 
 variable "tfc_agent_image" {
   type        = string
-  description = "TFC agent docker image.  Be mindful of docker hub rate limits"
+  description = "TFC agent docker image. Be mindful of docker hub rate limits"
   default     = "tfc-agent:latest"
+}
+
+variable "tfc_agent_env_vars" {
+  type        = list(object({ name = string, value = string }))
+  description = "A list of environment variables that should be present on each TFC agent."
+  default = [
+    {
+      name  = "TFC_AGENT_DISABLE_UPDATE"
+      value = "value"
+    },
+    {
+      name  = "TFC_AGENT_SINGLE"
+      value = "true"
+    },
+    {
+      name  = "TFC_AGENT_LOG_LEVEL"
+      value = "info"
+    }
+  ]
 }
 
 # IAM and secrets


### PR DESCRIPTION
You can now supply your own preferred list of environment variables, which is handy if you need to connect to a Terraform Enterprise instance, change the logging level, or use auto-update functionality.